### PR TITLE
Main qa list view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8013,6 +8013,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "moment": "^2.27.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,16 +1,16 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import { Grid, Paper, Button, Link, Typography } from "@material-ui/core";
+import { Grid, Button, Typography, Box } from "@material-ui/core";
 import SearchBar from "./SearchBar.jsx";
 import AddQuestion from "./AddQuestion.jsx";
 import MainQAList from "./MainQAList.jsx";
-import Helpful from "./Helpful.jsx";
+import sampleData from "../sampleQuestion";
 
 const useStyles = makeStyles((theme) => ({
   grid: {
     width: "100%",
     margin: "0px",
-    background: "#F1F1F1",
+    background: "#white",
     direction: "column",
     justify: "space-evenly",
     alignItems: "stretch",
@@ -26,38 +26,31 @@ const useStyles = makeStyles((theme) => ({
 const App = () => {
   const classes = useStyles();
   return (
-    <Grid container spacing={5} className={classes.grid}>
-      <span id="title">QUESTIONS & ANSWERS</span>
-      <Grid container item xs={12} spacing={2} className={classes.grid}>
-        <Grid id="searchBar" item xs={12}>
+    <Grid container className={classes.grid} direction="column">
+      <Grid item>
+        <Typography id="title">QUESTIONS & ANSWERS</Typography>
+      </Grid>
+
+      <Grid container item xs={12} className={classes.grid}>
+        <Grid item id="searchBar" xs={12}>
           <SearchBar />
         </Grid>
-        <Grid container item xs={9} direction="column">
-          <Paper item className={classes.paper}>
-            <MainQAList />
-          </Paper>
-        </Grid>
-        <Grid container item xs={3} justify={"space-evenly"}>
-          <Grid id="helpfulQuestion" item>
-            <Helpful storedCount={5} />
-          </Grid>
-          <Grid item>
-            <Typography>|</Typography>
-          </Grid>
-          <Link id="AddAnswer" href="#" color="inherit">
-            Add Answer
-          </Link>
-        </Grid>
-        <Grid container item xs={9}>
-          <Grid item xs={4}>
-            <Button variant="outlined" className={classes.button}>
-              MORE ANSWERED QUESTIONS
-            </Button>
-          </Grid>
-          <Grid id="addQuestion" item xs={4}>
-            <AddQuestion />
-          </Grid>
-        </Grid>
+      </Grid>
+
+      <Grid item xs={12}>
+        <MainQAList data={sampleData} />
+      </Grid>
+
+      <Grid container item>
+        <Box mx={1} mt={2}>
+          <Button variant="outlined" className={classes.button}>
+            <Typography variant="button">MORE ANSWERED QUESTIONS</Typography>
+          </Button>
+        </Box>
+
+        <Box mx={1} mt={2}>
+          <AddQuestion />
+        </Box>
       </Grid>
     </Grid>
   );

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -32,8 +32,8 @@ const App = () => {
       </Grid>
 
       <Grid container item xs={12} className={classes.grid}>
-        <Grid item id="searchBar" xs={12}>
-          <SearchBar />
+        <Grid item xs={12}>
+          <SearchBar id="searchBar" />
         </Grid>
       </Grid>
 
@@ -43,13 +43,17 @@ const App = () => {
 
       <Grid container item>
         <Box mx={1} mt={2}>
-          <Button variant="outlined" className={classes.button}>
+          <Button
+            id="moreQuestions"
+            variant="outlined"
+            className={classes.button}
+          >
             <Typography variant="button">MORE ANSWERED QUESTIONS</Typography>
           </Button>
         </Box>
 
         <Box mx={1} mt={2}>
-          <AddQuestion />
+          <AddQuestion id="addQuestion" />
         </Box>
       </Grid>
     </Grid>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import { Grid, Paper, Button, Link } from "@material-ui/core";
+import { Grid, Paper, Button, Link, Typography } from "@material-ui/core";
 import SearchBar from "./SearchBar.jsx";
 import AddQuestion from "./AddQuestion.jsx";
 import MainQAList from "./MainQAList.jsx";
@@ -39,9 +39,11 @@ const App = () => {
         </Grid>
         <Grid container item xs={3} justify={"space-evenly"}>
           <Grid id="helpfulQuestion" item>
-            <Helpful storedCount={5}/>
+            <Helpful storedCount={5} />
           </Grid>
-          <Grid item>|</Grid>
+          <Grid item>
+            <Typography>|</Typography>
+          </Grid>
           <Link id="AddAnswer" href="#" color="inherit">
             Add Answer
           </Link>

--- a/src/components/Helpful.jsx
+++ b/src/components/Helpful.jsx
@@ -9,7 +9,10 @@ import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
   helpfulStyles: {
-    color: "purple",
+    color: "inherit",
+  },
+  linkStyles: {
+    color: "inherit",
   },
 }));
 
@@ -37,13 +40,25 @@ const Helpful = ({ storedCount }) => {
 
   return (
     <Grid container xs={12} className={classes.helpfulStyles}>
-      <Typography>
-        Helpful?
-        <Link href="#" className={"helpfulClick"} onClick={isHelpful}>
-          Yes
-        </Link>
-        <span className={`clicks-${count}`}>({count})</span>
-      </Typography>
+      <Grid item xs={8}>
+        <Typography>Helpful?</Typography>
+      </Grid>
+
+      <Grid item xs={3}>
+        <Typography>
+          <Link
+            href="#"
+            className={("helpfulClick", classes.linkStyles)}
+            onClick={isHelpful}
+          >
+            Yes
+          </Link>
+        </Typography>
+      </Grid>
+
+      <Grid item xs={1}>
+        <Typography className={`clicks-${count}`}>({count})</Typography>
+      </Grid>
     </Grid>
   );
 };

--- a/src/components/Helpful.jsx
+++ b/src/components/Helpful.jsx
@@ -41,11 +41,11 @@ const Helpful = ({ storedCount }) => {
   return (
     <Grid container xs={12} className={classes.helpfulStyles}>
       <Grid item xs={8}>
-        <Typography>Helpful?</Typography>
+        <Typography variant="caption">Helpful?</Typography>
       </Grid>
 
       <Grid item xs={3}>
-        <Typography>
+        <Typography variant="caption">
           <Link
             href="#"
             className={("helpfulClick", classes.linkStyles)}
@@ -57,7 +57,9 @@ const Helpful = ({ storedCount }) => {
       </Grid>
 
       <Grid item xs={1}>
-        <Typography className={`clicks-${count}`}>({count})</Typography>
+        <Typography variant="caption" className={`clicks-${count}`}>
+          ({count})
+        </Typography>
       </Grid>
     </Grid>
   );

--- a/src/components/Helpful.jsx
+++ b/src/components/Helpful.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Grid, Typography, Link } from "@material-ui/core";
+import { Grid, Typography, Link, Box } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 
 // *** Helpful ***
@@ -39,28 +39,29 @@ const Helpful = ({ storedCount }) => {
   };
 
   return (
-    <Grid container xs={12} className={classes.helpfulStyles}>
-      <Grid item xs={8}>
+    <Grid container className={classes.helpfulStyles}>
+      <Box>
         <Typography variant="caption">Helpful?</Typography>
-      </Grid>
+      </Box>
 
-      <Grid item xs={3}>
+      <Box mx={1}>
         <Typography variant="caption">
           <Link
             href="#"
-            className={("helpfulClick", classes.linkStyles)}
+            id="helpfulClick"
+            className={classes.linkStyles}
             onClick={isHelpful}
           >
             Yes
           </Link>
         </Typography>
-      </Grid>
+      </Box>
 
-      <Grid item xs={1}>
+      <Box>
         <Typography variant="caption" className={`clicks-${count}`}>
           ({count})
         </Typography>
-      </Grid>
+      </Box>
     </Grid>
   );
 };

--- a/src/components/MainQAList.jsx
+++ b/src/components/MainQAList.jsx
@@ -1,92 +1,114 @@
 import React from "react";
-import { Grid, Typography } from "@material-ui/core";
+import { Grid, Typography, Link, Box } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import Helpful from "./Helpful.jsx";
-import sampleData from "../sampleQuestion";
+import moment from "moment";
 
+// Styles for the Q&A section
 const useStyles = makeStyles((theme) => ({
   questionStyles: {
     textAlign: "left",
-    color: "red",
+    color: "#101010",
   },
   answerStyles: {
     textAlign: "left",
-    color: "blue",
+    color: "#777",
   },
 }));
 
 // Component for the Q&A List section
-const MainQAList = () => {
+const MainQAList = ({ data }) => {
   const classes = useStyles();
 
-  console.log(sampleData);
-  return (
-    <Grid container>
-      <Grid container>
-        <Question />
-      </Grid>
+  const questionList = data.results.map((question) => {
+    return Question(question);
+  });
 
-      <Grid container alignItems="flex-start">
-        <Answers />
-      </Grid>
-    </Grid>
-  );
+  return <Box>{questionList}</Box>;
 };
 
 // Component for the Questions
-const Question = () => {
+const Question = (question) => {
   const classes = useStyles();
+
+  const answerList = Object.values(question.answers).map((answer) => {
+    return Answers(answer);
+  });
+
   return (
-    <Grid container className={classes.questionStyles}>
-      <Grid item xs={1}>
-        <Typography>Q:</Typography>
+    <Grid container>
+      <Grid container xs={9}>
+        <Box mr={3}>
+          <Typography>Q:</Typography>
+        </Box>
+
+        <Box>
+          <Typography>{question.question_body}</Typography>
+        </Box>
       </Grid>
-      <Grid item xs={11}>
-        <Typography>
-          Who What Which When where why whether how? Who What Which When where
-          why whether how? Who What Which When where why whether how?
-        </Typography>
+
+      <Grid container xs={3}>
+        <Box mx={1}>
+          <Helpful storedCount={5} />
+        </Box>
+        <Box mx={1}>
+          <Typography>|</Typography>
+        </Box>
+        <Box mx={1}>
+          <Link id="AddAnswer" href="#" color="inherit">
+            <Typography variant="caption">Add Answer</Typography>
+          </Link>
+        </Box>
+      </Grid>
+
+      <Grid container item xs={12}>
+        <Typography>{answerList}</Typography>
       </Grid>
     </Grid>
   );
 };
 
 // Component for the Answers
-const Answers = () => {
+const Answers = (answer) => {
   const classes = useStyles();
-  const username = "User1234";
-  const date = "January 1, 2019";
 
   return (
-    <Grid container className={classes.answerStyles}>
-      <Grid item xs={1}>
+    <Grid container key={answer.id} className={classes.answerStyles} xs={12}>
+      <Box mr={3}>
         <Typography>A:</Typography>
-      </Grid>
-      <Grid item xs={11}>
-        <Typography>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam,
-          deserunt. Lorem ipsum dolor sit amet consectetur adipisicing elit.
-          Nam, deserunt.
-        </Typography>
-        <Grid container item spacing={2}>
-          <Grid item>
-            <Typography>
-              by {username} {date}
-            </Typography>
-          </Grid>
-          <Grid item>
-            <Typography>|</Typography>
-          </Grid>
-          <Grid item>
-            <Helpful storedCount={3} />
-          </Grid>
-          <Grid item>
-            <Typography>|</Typography>
-          </Grid>
-          <Grid item>
-            <Typography>Report</Typography>
-          </Grid>
-        </Grid>
+      </Box>
+      <Box>
+        <Typography>{answer.body}</Typography>
+      </Box>
+
+      <Grid container item>
+        <Box ml={5}>
+          <Typography variant="caption">
+            by {answer.answerer_name}, {moment(answer.date).format("LL")}
+          </Typography>
+        </Box>
+        <Box mx={2}>
+          <Typography variant="caption">|</Typography>
+        </Box>
+        <Box mx={1}>
+          <Helpful storedCount={answer.helpfulness} />
+        </Box>
+        <Box mx={2}>
+          <Typography variant="caption">|</Typography>
+        </Box>
+        <Box mx={1}>
+          <Typography variant="caption">
+            <Link
+              href="#"
+              color="inherit"
+              onClick={() => {
+                alert("Reported!!!");
+              }}
+            >
+              Report
+            </Link>
+          </Typography>
+        </Box>
       </Grid>
     </Grid>
   );

--- a/src/components/MainQAList.jsx
+++ b/src/components/MainQAList.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Grid, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import Helpful from "./Helpful.jsx";
+import sampleData from "../sampleQuestion";
 
 const useStyles = makeStyles((theme) => ({
   questionStyles: {
@@ -14,9 +15,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+// Component for the Q&A List section
 const MainQAList = () => {
   const classes = useStyles();
 
+  console.log(sampleData);
   return (
     <Grid container>
       <Grid container>
@@ -30,6 +33,7 @@ const MainQAList = () => {
   );
 };
 
+// Component for the Questions
 const Question = () => {
   const classes = useStyles();
   return (
@@ -47,6 +51,7 @@ const Question = () => {
   );
 };
 
+// Component for the Answers
 const Answers = () => {
   const classes = useStyles();
   const username = "User1234";
@@ -63,14 +68,24 @@ const Answers = () => {
           deserunt. Lorem ipsum dolor sit amet consectetur adipisicing elit.
           Nam, deserunt.
         </Typography>
-        <Grid container item>
-          <Typography>
-            by {username} {date}
-          </Typography>
-          <Typography>. | .</Typography>
-          <Helpful storedCount={3} />
-          <Typography>. | .</Typography>
-          <Typography>Report</Typography>
+        <Grid container item spacing={2}>
+          <Grid item>
+            <Typography>
+              by {username} {date}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Typography>|</Typography>
+          </Grid>
+          <Grid item>
+            <Helpful storedCount={3} />
+          </Grid>
+          <Grid item>
+            <Typography>|</Typography>
+          </Grid>
+          <Grid item>
+            <Typography>Report</Typography>
+          </Grid>
         </Grid>
       </Grid>
     </Grid>

--- a/src/components/MainQAList.jsx
+++ b/src/components/MainQAList.jsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-// Component for the Q&A List section
+// Main Component for the Q&A List section
 const MainQAList = ({ data }) => {
   const classes = useStyles();
 
@@ -24,7 +24,7 @@ const MainQAList = ({ data }) => {
     return Question(question);
   });
 
-  return <Box>{questionList}</Box>;
+  return <Box className="main">{questionList}</Box>;
 };
 
 // Component for the Questions
@@ -36,18 +36,20 @@ const Question = (question) => {
   });
 
   return (
-    <Grid container>
-      <Grid container xs={9}>
+    <Grid key={question.question_id} container>
+      <Grid container item xs={9}>
         <Box mr={3}>
           <Typography>Q:</Typography>
         </Box>
 
         <Box>
-          <Typography>{question.question_body}</Typography>
+          <Typography className="questionBody">
+            {question.question_body}
+          </Typography>
         </Box>
       </Grid>
 
-      <Grid container xs={3}>
+      <Grid container item xs={3}>
         <Box mx={1}>
           <Helpful storedCount={5} />
         </Box>
@@ -73,32 +75,37 @@ const Answers = (answer) => {
   const classes = useStyles();
 
   return (
-    <Grid container key={answer.id} className={classes.answerStyles} xs={12}>
+    <Grid container key={answer.id} className={classes.answerStyles}>
       <Box mr={3}>
         <Typography>A:</Typography>
       </Box>
       <Box>
-        <Typography>{answer.body}</Typography>
+        <Typography className="answerBody">{answer.body}</Typography>
       </Box>
 
       <Grid container item>
         <Box ml={5}>
-          <Typography variant="caption">
+          <Typography variant="caption" className="answerName">
             by {answer.answerer_name}, {moment(answer.date).format("LL")}
           </Typography>
         </Box>
+
         <Box mx={2}>
           <Typography variant="caption">|</Typography>
         </Box>
+
         <Box mx={1}>
           <Helpful storedCount={answer.helpfulness} />
         </Box>
+
         <Box mx={2}>
           <Typography variant="caption">|</Typography>
         </Box>
+
         <Box mx={1}>
           <Typography variant="caption">
             <Link
+              className="reported"
               href="#"
               color="inherit"
               onClick={() => {

--- a/src/sampleQuestion.js
+++ b/src/sampleQuestion.js
@@ -1,0 +1,51 @@
+let sampleData = {
+  "product_id": "5",
+  "results": [{
+        "question_id": 37,
+        "question_body": "Why is this product cheaper here than other sites?",
+        "question_date": "2018-10-18T00:00:00.000Z",
+        "asker_name": "williamsmith",
+        "question_helpfulness": 4,
+        "reported": 0,
+        "answers": {
+          68: {
+            "id": 68,
+            "body": "We are selling it here without any markup from the middleman!",
+            "date": "2018-08-18T00:00:00.000Z",
+            "answerer_name": "Seller",
+            "helpfulness": 4,
+            "photos": []
+            // ...
+          }
+        }
+      },
+      {
+        "question_id": 38,
+        "question_body": "How long does it last?",
+        "question_date": "2019-06-28T00:00:00.000Z",
+        "asker_name": "funnygirl",
+        "question_helpfulness": 2,
+        "reported": 0,
+        "answers": {
+          70: {
+            "id": 70,
+            "body": "Some of the seams started splitting the first time I wore it!",
+            "date": "2019-11-28T00:00:00.000Z",
+            "answerer_name": "sillyguy",
+            "helpfulness": 6,
+            "photos": [],
+          },
+          78: {
+            "id": 78,
+            "body": "9 lives",
+            "date": "2019-11-12T00:00:00.000Z",
+            "answerer_name": "iluvdogz",
+            "helpfulness": 31,
+            "photos": [],
+          }
+        }
+      }
+  ]
+}
+
+export default sampleData;

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -25,6 +25,10 @@ describe("Basic Rendering", () => {
     expect(wrapper.exists("#searchBar")).toBe(true);
   });
 
+  test("Should contain a More Answered Question button", () => {
+    expect(wrapper.exists("#moreQuestions")).toBe(true);
+  });
+
   test("Should contain a Add Question component", () => {
     expect(wrapper.exists("#addQuestion")).toBe(true);
   });

--- a/test/Helpful.test.js
+++ b/test/Helpful.test.js
@@ -1,5 +1,4 @@
 import Helpful from "../src/components/Helpful";
-import { Link } from "@material-ui/core";
 
 import React from "react";
 import { configure, shallow } from "enzyme";
@@ -17,14 +16,14 @@ describe("Helpful Component Tests", () => {
 
   test("Should increment Helpful Count when clicked", () => {
     expect(wrapper.exists(".clicks-5")).toBe(true);
-    wrapper.find(".helpfulClick").simulate("click");
+    wrapper.find("#helpfulClick").simulate("click");
     expect(wrapper.exists(".clicks-6")).toBe(true);
   });
 
   test("Should return Helpful count to original value when clicked twice", () => {
-    wrapper.find(".helpfulClick").simulate("click");
+    wrapper.find("#helpfulClick").simulate("click");
     expect(wrapper.exists(".clicks-6")).toBe(true);
-    wrapper.find(".helpfulClick").simulate("click");
+    wrapper.find("#helpfulClick").simulate("click");
     expect(wrapper.exists(".clicks-5")).toBe(true);
   });
-});
+}); 

--- a/test/MainQAList.test.js
+++ b/test/MainQAList.test.js
@@ -1,0 +1,56 @@
+import MainQAList from "../src/components/MainQAList";
+
+import React from "react";
+import { configure, shallow, mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+configure({
+  adapter: new Adapter(),
+});
+
+describe("Main QA Component Testing", () => {
+  let wrapper, testData;
+
+  beforeEach(() => {
+    testData = {
+      product_id: "9",
+      results: [
+        {
+          question_id: 50,
+          question_body: "What fabric is the bottom made of?",
+          question_date: "2019-06-28T00:00:00.000Z",
+          asker_name: "l33tgamer",
+          question_helpfulness: 1,
+          reported: 0,
+          answers: {
+            "58": {
+              id: 58,
+              body: "Its a rubber sole",
+              date: "2019-11-28T00:00:00.000Z",
+              answerer_name: "n00bgamer",
+              helpfulness: 9,
+              photos: [],
+            },
+          },
+        },
+      ],
+    };
+
+    wrapper = mount(<MainQAList data={testData} />);
+  });
+
+  test("Should populate the Question", () => {
+    expect(wrapper.exists(".questionBody")).toBe(true);
+  });
+
+  test("Should populate the Answers", () => {
+    expect(wrapper.exists(".answerBody")).toBe(true);
+  });
+
+  test("Should populate the Answerers Name", () => {
+    expect(wrapper.exists(".answerName")).toBe(true);
+  });
+
+  test("Should have a reported feature", () => {
+    expect(wrapper.exists(".reported")).toBe(true);
+  });
+});


### PR DESCRIPTION
- Updated the Main QA view to render data passed in through props. 
- Will map through and render the questions and each question will map through and render its answers. 
- Moved the Helpful question and add answer section from the main App component to the MainQAList component. 
- Added temporary functionality to the Report button to just give an alert.
- Added testing suite for the MainQAList component.
- Updated the layout on all components to use Grid and Box.